### PR TITLE
cat is unneeded, update docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Cycles Per Instruction - The Kernel Module Edition
 Welcome to the most unnecessarily complicated netcat album release format yet. 
 
 In this repository, you will be able to compile your own kernel module, create a 
-`/dev/netcat` device and pipe its output into an audio player.
+`/dev/netcat` device and send its output into an audio player.
 
 ```
-cat /dev/netcat | ogg123 -
+ogg123 - < /dev/netcat
 ```
 
 This repository contains the album's track data in source files, that (for complexity's sake) came from `.ogg` files that were 
@@ -71,7 +71,7 @@ You should see output like the following from `dmesg`:
 [ 2606.528153] [netcat]: netcat - Cycles Per Instruction - Kernel Module Edition - 2014
 [ 2606.528153] [netcat]: netcat is Brandon Lucia, Andrew Olmstead, and David Balatero
 [ 2606.528153] [netcat]: Run 'sudo mknod /dev/netcat c 250 0' to setup the device.
-[ 2606.528153] [netcat]: 'cat /dev/netcat | ogg123 -' to play.
+[ 2606.528153] [netcat]: 'ogg123 - </dev/netcat' to play.
 ```
 
 Your `mknod` command will be slightly different, as the OS will assign you a different number every time. Run this command:
@@ -83,7 +83,7 @@ mknod /dev/netcat c <your number> 0
 Finally, put on some headphones, and run:
 
 ```
-cat /dev/netcat | ogg123 -
+/ogg123 - < dev/netcat
 ```
 
 Track information will show up in the output of `dmesg`:

--- a/netcat.c
+++ b/netcat.c
@@ -74,7 +74,7 @@ int init_module(void)
 	  return Major;
 	}
 
-	printk(KERN_INFO "[netcat]: netcat - Cycles Per Instruction - Kernel Module Edition - 2014\n[netcat]: netcat is Brandon Lucia, Andrew Olmstead, and David Balatero\n[netcat]: On the web at http://netcat.co\n[netcat]: Run 'sudo mknod /dev/netcat c %d 0' to setup the device.\n[netcat]: 'cat /dev/netcat | ogg123 -' to play.\n", Major);
+	printk(KERN_INFO "[netcat]: netcat - Cycles Per Instruction - Kernel Module Edition - 2014\n[netcat]: netcat is Brandon Lucia, Andrew Olmstead, and David Balatero\n[netcat]: On the web at http://netcat.co\n[netcat]: Run 'sudo mknod /dev/netcat c %d 0' to setup the device.\n[netcat]: 'ogg123 - </dev/netcat' to play.\n", Major);
 
 	return SUCCESS;
 }


### PR DESCRIPTION
Reported in #6 by @jmtd.

This updates the docs and the output in `netcat.c`.

@blucia0a We should merge #3 before we merge this one in, as there might be merge conflicts.
