### PR TITLE
A number of coding style cleanups for the netcat kernel module

### DIFF
--- a/netcat.c
+++ b/netcat.c
@@ -31,11 +31,11 @@ static ssize_t device_write(struct file *, const char *, size_t, loff_t *);
 #define SUCCESS 0
 #define DEVICE_NAME "netcat"	/* Dev name as it appears in /proc/devices   */
 
-static int Device_Open = 0;
+static int Device_Open;
 static char *msg_Ptr;
 
 static unsigned int firstTime = 1;
-static unsigned int currentTrack = 0;
+static unsigned int currentTrack;
 
 static char *tracks[] = {netcat_cpi_trk1,
 			 netcat_cpi_trk2,

--- a/netcat.c
+++ b/netcat.c
@@ -23,11 +23,6 @@
 #include <trk2.h>
 #include <trk3.h>
 
-static int device_open(struct inode *, struct file *);
-static int device_release(struct inode *, struct file *);
-static ssize_t device_read(struct file *, char *, size_t, loff_t *);
-static ssize_t device_write(struct file *, const char *, size_t, loff_t *);
-
 #define DEVICE_NAME "netcat"	/* Dev name as it appears in /proc/devices   */
 
 static int Device_Open;
@@ -57,21 +52,6 @@ static unsigned long tracklens[] = {NETCAT_CPI_TRK1_LEN,
 				    NETCAT_CPI_TRK5_LEN,
 				    NETCAT_CPI_TRK6_LEN};
 
-
-static const struct file_operations fops = {
-	.owner = THIS_MODULE,
-	.read = device_read,
-	.write = device_write,
-	.open = device_open,
-	.release = device_release
-};
-
-static struct miscdevice netcat_dev = {
-	.minor = MISC_DYNAMIC_MINOR,
-	.name = DEVICE_NAME,
-	.fops = &fops,
-	.mode = S_IRUGO,
-};
 
 static int device_open(struct inode *inode, struct file *file)
 {
@@ -130,6 +110,21 @@ device_write(struct file *filp, const char *buff, size_t len, loff_t *off)
 	pr_err("Writing to netcat - Cycles Per Instruction isn't supported.\n");
 	return -EINVAL;
 }
+
+static const struct file_operations fops = {
+	.owner = THIS_MODULE,
+	.read = device_read,
+	.write = device_write,
+	.open = device_open,
+	.release = device_release
+};
+
+static struct miscdevice netcat_dev = {
+	.minor = MISC_DYNAMIC_MINOR,
+	.name = DEVICE_NAME,
+	.fops = &fops,
+	.mode = S_IRUGO,
+};
 
 static int netcat_init(void)
 {

--- a/netcat.c
+++ b/netcat.c
@@ -60,6 +60,7 @@ static unsigned long tracklens[] = {NETCAT_CPI_TRK1_LEN,
 
 
 static const struct file_operations fops = {
+	.owner = THIS_MODULE,
 	.read = device_read,
 	.write = device_write,
 	.open = device_open,
@@ -80,7 +81,6 @@ static int device_open(struct inode *inode, struct file *file)
 
 	Device_Open++;
 	msg_Ptr = tracks[0];	/* track 1 */
-	try_module_get(THIS_MODULE);
 
 	return SUCCESS;
 }
@@ -88,8 +88,6 @@ static int device_open(struct inode *inode, struct file *file)
 static int device_release(struct inode *inode, struct file *file)
 {
 	Device_Open--;
-
-	module_put(THIS_MODULE);
 
 	return 0;
 }

--- a/netcat.c
+++ b/netcat.c
@@ -28,7 +28,6 @@ static int device_release(struct inode *, struct file *);
 static ssize_t device_read(struct file *, char *, size_t, loff_t *);
 static ssize_t device_write(struct file *, const char *, size_t, loff_t *);
 
-#define SUCCESS 0
 #define DEVICE_NAME "netcat"	/* Dev name as it appears in /proc/devices   */
 
 static int Device_Open;
@@ -82,7 +81,7 @@ static int device_open(struct inode *inode, struct file *file)
 	Device_Open++;
 	msg_Ptr = tracks[0];	/* track 1 */
 
-	return SUCCESS;
+	return 0;
 }
 
 static int device_release(struct inode *inode, struct file *file)
@@ -139,17 +138,14 @@ static int netcat_init(void)
 	ret = misc_register(&netcat_dev);
 	if (ret) {
 		pr_err("misc device register failed\n");
-		goto out_noreg;
+		return ret;
 	}
 	pr_info("netcat - Cycles Per Instruction - Kernel Module Edition - 2014\n");
 	pr_info("netcat is Brandon Lucia, Andrew Olmstead, and David Balatero\n");
 	pr_info("On the web at http://netcat.co\n");
 	pr_info("'ogg123 - < /dev/netcat' to play.\n");
 
-	return SUCCESS;
-
-out_noreg:
-	return ret;
+	return 0;
 }
 
 static void netcat_exit(void)

--- a/netcat.c
+++ b/netcat.c
@@ -67,10 +67,11 @@ static const struct file_operations fops = {
 };
 
 static struct miscdevice netcat_dev = {
-	MISC_DYNAMIC_MINOR,
-	DEVICE_NAME,
-	&fops,
-	};
+	.minor = MISC_DYNAMIC_MINOR,
+	.name = DEVICE_NAME,
+	.fops = &fops,
+	.mode = S_IRUGO,
+};
 
 static int device_open(struct inode *inode, struct file *file)
 {
@@ -136,7 +137,7 @@ device_write(struct file *filp, const char *buff, size_t len, loff_t *off)
 static int netcat_init(void)
 {
 	int ret;
-	netcat_dev.mode = S_IRUGO;
+
 	ret = misc_register(&netcat_dev);
 	if (ret) {
 		pr_err("misc device register failed\n");

--- a/netcat.c
+++ b/netcat.c
@@ -21,8 +21,6 @@
 #include <trk2.h>
 #include <trk3.h>
 
-int init_module(void);
-void cleanup_module(void);
 static int device_open(struct inode *, struct file *);
 static int device_release(struct inode *, struct file *);
 static ssize_t device_read(struct file *, char *, size_t, loff_t *);
@@ -71,29 +69,6 @@ static struct miscdevice netcat_dev = {
 	DEVICE_NAME,
 	&fops,
 	};
-
-int init_module(void)
-{
-	int ret;
-	netcat_dev.mode=S_IRUGO;
-	ret = misc_register(&netcat_dev);
-	if (ret){
-		printk(KERN_ERR "netcat: misc device register failed\n");
-		goto out_noreg;
-	}
-	printk(KERN_INFO "[netcat]: netcat - Cycles Per Instruction - Kernel Module Edition - 2014\n[netcat]: netcat is Brandon Lucia, Andrew Olmstead, and David Balatero\n[netcat]: On the web at http://netcat.co\n[netcat]: 'ogg123 - < /dev/netcat' to play.\n");
-
-	return SUCCESS;
-
-	out_noreg:
-	return ret;
-}
-
-void cleanup_module(void)
-{
-	misc_deregister(&netcat_dev);
-}
-
 
 static int device_open(struct inode *inode, struct file *file)
 {
@@ -153,3 +128,28 @@ device_write(struct file *filp, const char *buff, size_t len, loff_t * off)
 	printk(KERN_ALERT "[netcat]: Writing to netcat - Cycles Per Instruction isn't supported.\n");
 	return -EINVAL;
 }
+
+static int netcat_init(void)
+{
+	int ret;
+	netcat_dev.mode=S_IRUGO;
+	ret = misc_register(&netcat_dev);
+	if (ret){
+		printk(KERN_ERR "netcat: misc device register failed\n");
+		goto out_noreg;
+	}
+	printk(KERN_INFO "[netcat]: netcat - Cycles Per Instruction - Kernel Module Edition - 2014\n[netcat]: netcat is Brandon Lucia, Andrew Olmstead, and David Balatero\n[netcat]: On the web at http://netcat.co\n[netcat]: 'ogg123 - < /dev/netcat' to play.\n");
+
+	return SUCCESS;
+
+	out_noreg:
+	return ret;
+}
+
+static void netcat_exit(void)
+{
+	misc_deregister(&netcat_dev);
+}
+
+module_init(netcat_init);
+module_exit(netcat_exit);

--- a/netcat.c
+++ b/netcat.c
@@ -1,7 +1,7 @@
 #include <linux/kernel.h>
 #include <linux/module.h>
 #include <linux/fs.h>
-#include <asm/uaccess.h>
+#include <linux/uaccess.h>
 #include <linux/miscdevice.h>
 
 /* Brandon's compiler crashes unless we include them in
@@ -57,7 +57,7 @@ static unsigned long tracklens[] = {NETCAT_CPI_TRK1_LEN,
 				    NETCAT_CPI_TRK6_LEN};
 
 
-static struct file_operations fops = {
+static const struct file_operations fops = {
 	.read = device_read,
 	.write = device_write,
 	.open = device_open,
@@ -94,21 +94,21 @@ static int device_release(struct inode *inode, struct file *file)
 static ssize_t device_read(struct file *filp,
 			   char *buffer,
 			   size_t length,
-			   loff_t * offset)
+			   loff_t *offset)
 {
 	int bytes_read = 0;
 
 	if (firstTime == 1) {
-		printk(KERN_ALERT "[netcat]: Now playing track %d - %s\n",currentTrack + 1,tracknames[currentTrack]);
+		printk(KERN_ALERT "[netcat]: Now playing track %d - %s\n", currentTrack + 1, tracknames[currentTrack]);
 		firstTime = 0;
 	}
 
 	if (msg_Ptr - tracks[currentTrack] >= tracklens[currentTrack]) {
-		/*End of Track.  Skip to next track, or finish if it's track 6*/ 
+		/*End of Track.  Skip to next track, or finish if it's track 6*/
 		currentTrack = (currentTrack + 1);
 		if (currentTrack >= 6)
 			currentTrack = 0;
-		printk(KERN_ALERT "[netcat]: Now playing track %d - %s\n",currentTrack + 1,tracknames[currentTrack]);
+		printk(KERN_ALERT "[netcat]: Now playing track %d - %s\n", currentTrack + 1, tracknames[currentTrack]);
 		msg_Ptr = tracks[currentTrack];
 	}
 
@@ -123,7 +123,7 @@ static ssize_t device_read(struct file *filp,
 }
 
 static ssize_t
-device_write(struct file *filp, const char *buff, size_t len, loff_t * off)
+device_write(struct file *filp, const char *buff, size_t len, loff_t *off)
 {
 	printk(KERN_ALERT "[netcat]: Writing to netcat - Cycles Per Instruction isn't supported.\n");
 	return -EINVAL;
@@ -132,9 +132,9 @@ device_write(struct file *filp, const char *buff, size_t len, loff_t * off)
 static int netcat_init(void)
 {
 	int ret;
-	netcat_dev.mode=S_IRUGO;
+	netcat_dev.mode = S_IRUGO;
 	ret = misc_register(&netcat_dev);
-	if (ret){
+	if (ret) {
 		printk(KERN_ERR "netcat: misc device register failed\n");
 		goto out_noreg;
 	}
@@ -142,7 +142,7 @@ static int netcat_init(void)
 
 	return SUCCESS;
 
-	out_noreg:
+out_noreg:
 	return ret;
 }
 

--- a/netcat.c
+++ b/netcat.c
@@ -1,3 +1,5 @@
+#define pr_fmt(fmt) "[" KBUILD_MODNAME "]: " fmt
+
 #include <linux/kernel.h>
 #include <linux/module.h>
 #include <linux/fs.h>
@@ -99,7 +101,8 @@ static ssize_t device_read(struct file *filp,
 	int bytes_read = 0;
 
 	if (firstTime == 1) {
-		printk(KERN_ALERT "[netcat]: Now playing track %d - %s\n", currentTrack + 1, tracknames[currentTrack]);
+		pr_info("Now playing track %d - %s\n",
+			currentTrack + 1, tracknames[currentTrack]);
 		firstTime = 0;
 	}
 
@@ -108,7 +111,8 @@ static ssize_t device_read(struct file *filp,
 		currentTrack = (currentTrack + 1);
 		if (currentTrack >= 6)
 			currentTrack = 0;
-		printk(KERN_ALERT "[netcat]: Now playing track %d - %s\n", currentTrack + 1, tracknames[currentTrack]);
+		pr_info("Now playing track %d - %s\n",
+			currentTrack + 1, tracknames[currentTrack]);
 		msg_Ptr = tracks[currentTrack];
 	}
 
@@ -125,7 +129,7 @@ static ssize_t device_read(struct file *filp,
 static ssize_t
 device_write(struct file *filp, const char *buff, size_t len, loff_t *off)
 {
-	printk(KERN_ALERT "[netcat]: Writing to netcat - Cycles Per Instruction isn't supported.\n");
+	pr_err("Writing to netcat - Cycles Per Instruction isn't supported.\n");
 	return -EINVAL;
 }
 
@@ -135,10 +139,13 @@ static int netcat_init(void)
 	netcat_dev.mode = S_IRUGO;
 	ret = misc_register(&netcat_dev);
 	if (ret) {
-		printk(KERN_ERR "netcat: misc device register failed\n");
+		pr_err("misc device register failed\n");
 		goto out_noreg;
 	}
-	printk(KERN_INFO "[netcat]: netcat - Cycles Per Instruction - Kernel Module Edition - 2014\n[netcat]: netcat is Brandon Lucia, Andrew Olmstead, and David Balatero\n[netcat]: On the web at http://netcat.co\n[netcat]: 'ogg123 - < /dev/netcat' to play.\n");
+	pr_info("netcat - Cycles Per Instruction - Kernel Module Edition - 2014\n");
+	pr_info("netcat is Brandon Lucia, Andrew Olmstead, and David Balatero\n");
+	pr_info("On the web at http://netcat.co\n");
+	pr_info("'ogg123 - < /dev/netcat' to play.\n");
 
 	return SUCCESS;
 

--- a/netcat.c
+++ b/netcat.c
@@ -3,15 +3,17 @@
 #include <linux/fs.h>
 #include <asm/uaccess.h>
 #include <linux/miscdevice.h>
-// Brandon's compiler crashes unless we include them in
-// this order.
-//
-//   __                               __
-// _/  |_  ____   ____ _____    _____/  |_
-// \   __\/ __ \ /    \\__  \ _/ ___\   __\
-//  |  | \  ___/|   |  \/ __ \\  \___|  |
-//  |__|  \___  >___|  (____  /\___  >__|
-//            \/     \/     \/     \/
+
+/* Brandon's compiler crashes unless we include them in
+ * this order.
+ *
+ *   __                               __
+ * _/  |_  ____   ____ _____    _____/  |_
+ * \   __\/ __ \ /    \\__  \ _/ ___\   __\
+ *  |  | \  ___/|   |  \/ __ \\  \___|  |
+ *  |__|  \___  >___|  (____  /\___  >__|
+ *            \/     \/     \/     \/
+ */
 #include <trk4.h>
 #include <trk5.h>
 #include <trk6.h>
@@ -99,7 +101,7 @@ static int device_open(struct inode *inode, struct file *file)
 		return -EBUSY;
 
 	Device_Open++;
-	msg_Ptr = tracks[0];//track 1
+	msg_Ptr = tracks[0];	/* track 1 */
 	try_module_get(THIS_MODULE);
 
 	return SUCCESS;

--- a/netcat.c
+++ b/netcat.c
@@ -1,17 +1,17 @@
 #include <linux/kernel.h>
 #include <linux/module.h>
 #include <linux/fs.h>
-#include <asm/uaccess.h>	
+#include <asm/uaccess.h>
 #include <linux/miscdevice.h>
 // Brandon's compiler crashes unless we include them in
 // this order.
 //
-//   __                               __   
-// _/  |_  ____   ____ _____    _____/  |_ 
+//   __                               __
+// _/  |_  ____   ____ _____    _____/  |_
 // \   __\/ __ \ /    \\__  \ _/ ___\   __\
-//  |  | \  ___/|   |  \/ __ \\  \___|  |  
-//  |__|  \___  >___|  (____  /\___  >__|  
-//            \/     \/     \/     \/      
+//  |  | \  ___/|   |  \/ __ \\  \___|  |
+//  |__|  \___  >___|  (____  /\___  >__|
+//            \/     \/     \/     \/
 #include <trk4.h>
 #include <trk5.h>
 #include <trk6.h>
@@ -29,32 +29,32 @@ static ssize_t device_write(struct file *, const char *, size_t, loff_t *);
 #define SUCCESS 0
 #define DEVICE_NAME "netcat"	/* Dev name as it appears in /proc/devices   */
 
-static int Device_Open = 0;	
+static int Device_Open = 0;
 static char *msg_Ptr;
 
 static unsigned int firstTime = 1;
 static unsigned int currentTrack = 0;
 
 static char *tracks[] = {netcat_cpi_trk1,
-                         netcat_cpi_trk2,
-                         netcat_cpi_trk3,
-                         netcat_cpi_trk4,
-                         netcat_cpi_trk5,
-                         netcat_cpi_trk6};
+			 netcat_cpi_trk2,
+			 netcat_cpi_trk3,
+			 netcat_cpi_trk4,
+			 netcat_cpi_trk5,
+			 netcat_cpi_trk6};
 
 static char *tracknames[] = {"Interrupt 0x7f",
-                         "The Internet is an Apt Motherfucker",
-                         "Interrupt 0x0d",
-                         "netcat",
-                         "Interrupt 0xbb",
-                         "Approximating the Circumference of the Earth"};
+			 "The Internet is an Apt Motherfucker",
+			 "Interrupt 0x0d",
+			 "netcat",
+			 "Interrupt 0xbb",
+			 "Approximating the Circumference of the Earth"};
 
 static unsigned long tracklens[] = {NETCAT_CPI_TRK1_LEN,
-                                    NETCAT_CPI_TRK2_LEN,
-                                    NETCAT_CPI_TRK3_LEN,
-                                    NETCAT_CPI_TRK4_LEN,
-                                    NETCAT_CPI_TRK5_LEN,
-                                    NETCAT_CPI_TRK6_LEN};
+				    NETCAT_CPI_TRK2_LEN,
+				    NETCAT_CPI_TRK3_LEN,
+				    NETCAT_CPI_TRK4_LEN,
+				    NETCAT_CPI_TRK5_LEN,
+				    NETCAT_CPI_TRK6_LEN};
 
 
 static struct file_operations fops = {
@@ -107,39 +107,35 @@ static int device_open(struct inode *inode, struct file *file)
 
 static int device_release(struct inode *inode, struct file *file)
 {
-	Device_Open--;		
+	Device_Open--;
 
 	module_put(THIS_MODULE);
 
 	return 0;
 }
 
-static ssize_t device_read(struct file *filp,	
-			   char *buffer,	
-			   size_t length,	
+static ssize_t device_read(struct file *filp,
+			   char *buffer,
+			   size_t length,
 			   loff_t * offset)
 {
 	int bytes_read = 0;
 
-        if( firstTime == 1 ){
+	if (firstTime == 1) {
+		printk(KERN_ALERT "[netcat]: Now playing track %d - %s\n",currentTrack + 1,tracknames[currentTrack]);
+		firstTime = 0;
+	}
 
-	  printk(KERN_ALERT "[netcat]: Now playing track %d - %s\n",currentTrack + 1,tracknames[currentTrack]);
-          firstTime = 0;
-
-        }
-
-	if (msg_Ptr - tracks[currentTrack] >= tracklens[currentTrack]){
-
-          /*End of Track.  Skip to next track, or finish if it's track 6*/ 
-          currentTrack = (currentTrack + 1);
-          if( currentTrack >= 6 ){ currentTrack = 0; }
-	  printk(KERN_ALERT "[netcat]: Now playing track %d - %s\n",currentTrack + 1,tracknames[currentTrack]);
-          msg_Ptr = tracks[currentTrack];
-
-        }
+	if (msg_Ptr - tracks[currentTrack] >= tracklens[currentTrack]) {
+		/*End of Track.  Skip to next track, or finish if it's track 6*/ 
+		currentTrack = (currentTrack + 1);
+		if (currentTrack >= 6)
+			currentTrack = 0;
+		printk(KERN_ALERT "[netcat]: Now playing track %d - %s\n",currentTrack + 1,tracknames[currentTrack]);
+		msg_Ptr = tracks[currentTrack];
+	}
 
 	while (length && msg_Ptr - tracks[currentTrack] < tracklens[currentTrack]) {
-
 		put_user(*(msg_Ptr++), buffer++);
 
 		length--;


### PR DESCRIPTION
Some basic whitespace and other formatting tweaks to get the netcat kernel module
to abide by the basic Linux kernel coding style rules.
