### PR TITLE
replaced hard-coded number of tracks with sizeof

### DIFF
--- a/netcat.c
+++ b/netcat.c
@@ -95,7 +95,7 @@ static ssize_t device_read(struct file *file,
 	if (netcat->msg - tracks[current_track] >= tracklens[current_track]) {
 		/* End of Track.  Skip to next track, or finish if it's the last track */
 		current_track++;
-		if (current_track >= sizeof(tracks)/sizeof(tracks[0]))
+		if (current_track >= ARRAY_SIZE(tracks))
 			current_track = 0;
 		pr_info("Now playing track %d - %s\n",
 			current_track + 1, tracknames[current_track]);

--- a/netcat.c
+++ b/netcat.c
@@ -93,9 +93,9 @@ static ssize_t device_read(struct file *file,
 	}
 
 	if (netcat->msg - tracks[current_track] >= tracklens[current_track]) {
-		/* End of Track.  Skip to next track, or finish if it's track 6 */
+		/* End of Track.  Skip to next track, or finish if it's the last track */
 		current_track++;
-		if (current_track >= 6)
+		if (current_track >= sizeof(tracks)/sizeof(tracks[0]))
 			current_track = 0;
 		pr_info("Now playing track %d - %s\n",
 			current_track + 1, tracknames[current_track]);


### PR DESCRIPTION
This replaces the hard-coded '6' with the usual sizeof magic, which is
an important improvement to ease further releases with a different
number of tracks ;-)
