### PR TITLE
Get rid of hard-coded track lengths

### DIFF
--- a/netcat.h
+++ b/netcat.h
@@ -4,7 +4,7 @@
 struct netcat_track {
 	char *name;
 	unsigned long len;
-	char data[];
+	const char *data;
 };
 
 #endif /* NETCAT_H_INCLUDED_ */

--- a/netcat.h
+++ b/netcat.h
@@ -1,9 +1,10 @@
 #ifndef NETCAT_H_INCLUDED_
+#define NETCAT_H_INCLUDED_
+
 struct netcat_track {
 	char *name;
 	unsigned long len;
 	char data[];
 };
-
 
 #endif /* NETCAT_H_INCLUDED_ */

--- a/netcat_main.c
+++ b/netcat_main.c
@@ -10,9 +10,9 @@
 #include "netcat.h"
 
 struct netcat {
-	char	*msg;
-	bool	first_time;
-	int	current_track;
+	const char	*msg;
+	bool		first_time;
+	int		current_track;
 };
 
 #define DEVICE_NAME "netcat"	/* Dev name as it appears in /proc/devices   */

--- a/tracks/trk1.c
+++ b/tracks/trk1.c
@@ -1,9 +1,13 @@
+#include <linux/bug.h>
+#include <linux/kernel.h>
 #include "../netcat.h"
-#define NETCAT_CPI_TRK1_LEN 624344
+
+static const char trk1_data[] = {
+	#include "trk1data.h"
+};
+
 struct netcat_track netcat_cpi_trk1 = {
 	.name = "Interrupt 0x7f",
-	.len  = NETCAT_CPI_TRK1_LEN,
-	.data = {
-#include "trk1data.h"
-	}
+	.len  = ARRAY_SIZE(trk1_data),
+	.data = trk1_data
 };

--- a/tracks/trk2.c
+++ b/tracks/trk2.c
@@ -1,9 +1,13 @@
+#include <linux/bug.h>
+#include <linux/kernel.h>
 #include "../netcat.h"
-#define NETCAT_CPI_TRK2_LEN 11659615
+
+static const char trk2_data[] = {
+	#include "trk2data.h"
+};
+
 struct netcat_track netcat_cpi_trk2 = {
 	.name = "The Internet is an Apt Motherfucker",
-	.len  = NETCAT_CPI_TRK2_LEN,
-	.data = {
-#include "trk2data.h"
-	}
+	.len  = ARRAY_SIZE(trk2_data),
+	.data = trk2_data
 };

--- a/tracks/trk3.c
+++ b/tracks/trk3.c
@@ -1,9 +1,13 @@
+#include <linux/bug.h>
+#include <linux/kernel.h>
 #include "../netcat.h"
-#define NETCAT_CPI_TRK3_LEN 829971
+
+static const char trk3_data[] = {
+	#include "trk3data.h"
+};
+
 struct netcat_track netcat_cpi_trk3 = {
 	.name = "Interrupt 0x0d",
-	.len  = NETCAT_CPI_TRK3_LEN,
-	.data = {
-#include "trk3data.h"
-	}
+	.len  = ARRAY_SIZE(trk3_data),
+	.data = trk3_data
 };

--- a/tracks/trk4.c
+++ b/tracks/trk4.c
@@ -1,9 +1,13 @@
+#include <linux/bug.h>
+#include <linux/kernel.h>
 #include "../netcat.h"
-#define NETCAT_CPI_TRK4_LEN 10788741
+
+static const char trk4_data[] = {
+	#include "trk4data.h"
+};
+
 struct netcat_track netcat_cpi_trk4 = {
 	.name = "netcat",
-	.len  = NETCAT_CPI_TRK4_LEN,
-	.data = {
-#include "trk4data.h"
-	}
+	.len  = ARRAY_SIZE(trk4_data),
+	.data = trk4_data
 };

--- a/tracks/trk5.c
+++ b/tracks/trk5.c
@@ -1,9 +1,13 @@
+#include <linux/bug.h>
+#include <linux/kernel.h>
 #include "../netcat.h"
-#define NETCAT_CPI_TRK5_LEN 858054
+
+static const char trk5_data[] = {
+	#include "trk5data.h"
+};
+
 struct netcat_track netcat_cpi_trk5 = {
 	.name = "Interrupt 0xbb",
-	.len  = NETCAT_CPI_TRK5_LEN,
-	.data = {
-#include "trk5data.h"
-	}
+	.len  = ARRAY_SIZE(trk5_data),
+	.data = trk5_data
 };

--- a/tracks/trk6.c
+++ b/tracks/trk6.c
@@ -1,9 +1,13 @@
+#include <linux/bug.h>
+#include <linux/kernel.h>
 #include "../netcat.h"
-#define NETCAT_CPI_TRK6_LEN 13025371
+
+static const char trk6_data[] = {
+	#include "trk6data.h"
+};
+
 struct netcat_track netcat_cpi_trk6 = {
 	.name = "Approximating the Circumference of the Earth",
-	.len  = NETCAT_CPI_TRK6_LEN,
-	.data = {
-#include "trk6data.h"
-	}
+	.len  = ARRAY_SIZE(trk6_data),
+	.data = trk6_data
 };


### PR DESCRIPTION
Additional usage of the ARRAY_SIZE macro, plus a fix of the include guard.
