### PR TITLE
Added __init and __exit macros

### DIFF
--- a/netcat_main.c
+++ b/netcat_main.c
@@ -6,6 +6,7 @@
 #include <linux/uaccess.h>
 #include <linux/miscdevice.h>
 #include <linux/slab.h>
+#include <linux/init.h>
 
 #include "netcat.h"
 
@@ -115,7 +116,7 @@ static struct miscdevice netcat_dev = {
 	.mode = S_IRUGO,
 };
 
-static int netcat_init(void)
+static int __init netcat_init(void)
 {
 	int ret;
 
@@ -132,7 +133,7 @@ static int netcat_init(void)
 	return 0;
 }
 
-static void netcat_exit(void)
+static void __exit netcat_exit(void)
 {
 	misc_deregister(&netcat_dev);
 }


### PR DESCRIPTION
As defined in linux/init.h this will free space defined for init/exit functions after they will finish. Haven't tried to compile as I am not on linux machine right now, but I will try once I'll get home.
